### PR TITLE
Fix downloads

### DIFF
--- a/installscript.sh
+++ b/installscript.sh
@@ -87,7 +87,7 @@ installpkg *
 cd /tmp
 
 # install jq
-jq_v=1.6
+jq_v=1.7.1
 wget -O /tmp/jq-${jq_v}-x86_64-1alien.txz https://slackware.uk/people/alien/sbrepos/current/x86_64/jq/jq-${jq_v}-x86_64-1alien.txz
 installpkg /tmp/jq-${jq_v}-x86_64-1alien.txz
 

--- a/installscript.sh
+++ b/installscript.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Slackware server URL
-server_url="http://mirrors.slackware.com/slackware/slackware64-current/"
+server_url="http://mirrors.slackware.com/slackware/slackware64-current/slackware64/"
 
 # package names without version number
 packages=(
@@ -62,7 +62,7 @@ packages=(
 )
 
 # download FILELIST.TXT to get list of packages
-wget -O /tmp/FILELIST.TXT "${server_url}/FILELIST.TXT"
+wget -O /tmp/FILELIST.TXT "${server_url}/FILE_LIST"
 
 # create packages directory
 mkdir -p /tmp/packages


### PR DESCRIPTION
Change $server_url to slackware64 dir.
Different cmake versions exist in the
pastures and slackware64 directory,
both versions getting amended
to the same line in FILELIST.TXT.